### PR TITLE
add check to avoid NPE

### DIFF
--- a/pagertabsindicator/src/main/java/com/hold1/pagertabsindicator/PagerTabsIndicator.java
+++ b/pagertabsindicator/src/main/java/com/hold1/pagertabsindicator/PagerTabsIndicator.java
@@ -456,10 +456,12 @@ public class PagerTabsIndicator extends HorizontalScrollView implements ViewPage
     //Listen View Pager events
     @Override
     public void onPageScrolled(int position, float positionOffset, int positionOffsetPixels) {
+        Log.d(TAG, "onPageScrolled:position=" + position + ";positionOffset:" + positionOffset + ";tabsContainer child count:" + tabsContainer.getChildCount());
         this.position = position;
         this.positionOffset = positionOffset;
-        if (targetPosition == -1)
+        if (targetPosition == -1 && tabsContainer.getChildCount() > position) {
             scrollToChild(position, (int) (positionOffset * tabsContainer.getChildAt(position).getWidth()));
+        }
         int targetPosition = Math.round(position + positionOffset);
         float targetOffset = (float) Math.abs(0.5 - positionOffset) * 2;
         for (int i = 0; i < tabsContainer.getChildCount(); i++) {


### PR DESCRIPTION
Hello,

We have discovered following crash on our side:

**Fatal Exception: java.lang.NullPointerException: Attempt to invoke virtual method 'int android.view.View.getWidth()' on a null object reference**
       **at com.hold1.pagertabsindicator.PagerTabsIndicator.onPageScrolled + 462(PagerTabsIndicator.java:462)**
       at androidx.viewpager.widget.ViewPager.dispatchOnPageScrolled + 1930(ViewPager.java:1930)
       at androidx.viewpager.widget.ViewPager.onPageScrolled + 1904(ViewPager.java:1904)
       at androidx.viewpager.widget.ViewPager.pageScrolled + 1842(ViewPager.java:1842)
       at androidx.viewpager.widget.ViewPager.scrollToItem + 694(ViewPager.java:694)
       at androidx.viewpager.widget.ViewPager.onLayout + 1786(ViewPager.java:1786)
       at android.view.View.layout + 18010(View.java:18010)
       at android.view.ViewGroup.layout + 5911(ViewGroup.java:5911)
       at android.widget.LinearLayout.setChildFrame + 1742(LinearLayout.java:1742)
       at android.widget.LinearLayout.layoutVertical + 1585(LinearLayout.java:1585)
       at android.widget.LinearLayout.onLayout + 1494(LinearLayout.java:1494)
       at android.view.View.layout + 18010(View.java:18010)
       at android.view.ViewGroup.layout + 5911(ViewGroup.java:5911)
      at android.view.ViewGroup.layout + 5911(ViewGroup.java:5911)
       at android.widget.FrameLayout.layoutChildren + 344(FrameLayout.java:344)
       at android.widget.FrameLayout.onLayout + 281(FrameLayout.java:281)
       at android.view.View.layout + 18010(View.java:18010)
       at android.view.ViewGroup.layout + 5911(ViewGroup.java:5911)
       at android.widget.LinearLayout.setChildFrame + 1742(LinearLayout.java:1742)
       at android.widget.LinearLayout.layoutVertical + 1585(LinearLayout.java:1585)
       at android.widget.LinearLayout.onLayout + 1494(LinearLayout.java:1494)
       at android.view.View.layout + 18010(View.java:18010)
       at android.view.ViewGroup.layout + 5911(ViewGroup.java:5911)
       at android.widget.FrameLayout.layoutChildren + 344(FrameLayout.java:344)
       at android.widget.FrameLayout.onLayout + 281(FrameLayout.java:281)
       at android.view.View.layout + 18010(View.java:18010)
       at android.view.ViewGroup.layout + 5911(ViewGroup.java:5911)
       ...... "

 Since I cannot reproduce the scenario for this situation, I added some extra log and extra check to avoid this. Not sure if it's the best solution though.
